### PR TITLE
Patch: Update image version for openproblems/base_* images

### DIFF
--- a/src/methods/multi_omics/celloracle/cicero/config.vsh.yaml
+++ b/src/methods/multi_omics/celloracle/cicero/config.vsh.yaml
@@ -17,7 +17,7 @@ resources:
 engines:
   - type: docker
 
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: apt
         packages: [python3-venv python3-pip python3-dev]

--- a/src/methods/multi_omics/granie/config.vsh.yaml
+++ b/src/methods/multi_omics/granie/config.vsh.yaml
@@ -149,7 +149,7 @@ engines:
     # image: chrarnold84/granieverse:v1.3
     image: janursa/granie:01.04.2025
 
-    # image: openproblems/base_r:1.0.0
+    # image: openproblems/base_r:1
     # setup:
     #   - type: apt
     #     packages: [python3-venv python3-pip python3-dev]

--- a/src/methods/single_omics/repo/scgpt/config.novsh.yaml
+++ b/src/methods/single_omics/repo/scgpt/config.novsh.yaml
@@ -34,7 +34,7 @@ engines:
   #     - type: python
   #       packages: [ gdown ]
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     __merge__: /src/api/base_requirements.yaml
     # TODO: Try to find working installation of flash attention (flash-attn<1.0.5)
     setup:

--- a/src/methods/single_omics/scprint/config.vsh.yaml
+++ b/src/methods/single_omics/scprint/config.vsh.yaml
@@ -50,7 +50,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         pip:


### PR DESCRIPTION
This PR updates the image version from :1.0.0 to :1 for `openproblems/base_*` images.